### PR TITLE
Update inky_uc8159.ts

### DIFF
--- a/src/inky_uc8159.ts
+++ b/src/inky_uc8159.ts
@@ -78,7 +78,7 @@ class Inky_uc extends Inky_Colour {
             })
             rpio.spiBegin();
             rpio.spiChipSelect(0);
-            rpio.spiSetClockDivider(250000000 / 3000000); // 25MHz
+            rpio.spiSetClockDivider(84); // 25MHz
 
             rpio.open(this.cs_pin, rpio.OUTPUT)
             rpio.open(this.dc_pin, rpio.OUTPUT, rpio.PULL_OFF)
@@ -122,7 +122,7 @@ class Inky_uc extends Inky_Colour {
         this.send_command(
             UC8159_PSR,
             [
-                (this.resolution_setting << 6) | 0b101111,  // See above for more magic numbers
+                (this.resolution_setting << 6) | 0b11101111,  // See above for more magic numbers
                 0x08                                        // display_colours == UC8159_7C
             ]
         )


### PR DESCRIPTION
adjusted some minor configurations and tested with a 5.7 Inky display

- Small fixes, change the setClockDivider to 84 (the current division results in 83.333 which throws an exception)
- Adapte the resolution configuration to display the image properly